### PR TITLE
Corrección de conexión a mongoDB

### DIFF
--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -5,7 +5,7 @@ const USER = encodeURIComponent(config.dbUser);
 const PASSWORD = encodeURIComponent(config.dbPassword);
 const DB_NAME = config.dbName;
 
-const MONGO_URI = `mongodb+srv://${USER}:${PASSWORD}@${config.dbHost}:${config.dbPort}/${DB_NAME}?retryWrites=true&w=majority`;
+const MONGO_URI = `mongodb+srv://${USER}:${PASSWORD}@${config.dbHost}/${DB_NAME}?retryWrites=true&w=majority&useUnifiedTopology=true`;
 
 
 class MongoLib {
@@ -67,7 +67,7 @@ class MongoLib {
       .then(db => {
         return db.collection(collection).deleteOne({ _id: ObjectID(id) });
       })
-      .then(() => Id);
+      .then(() => id);
   }
 }
 


### PR DESCRIPTION
Hola @chestergalindo 

1. en el archivo /lib/mongo.js en el puerto se estaba utilizando el mismo del express el 3000 para mongo atlas no es necesario colocar el puerto

2. en la función delete() se está recibiendo el parametro en minuscula, y donde se usa est;a con mayúscula la primera, en js es muy sensible a las mayúsculas

